### PR TITLE
make shell scripts more portable

### DIFF
--- a/dependencies/scripts/initialize-accumulo.sh
+++ b/dependencies/scripts/initialize-accumulo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`

--- a/dependencies/scripts/start-accumulo.sh
+++ b/dependencies/scripts/start-accumulo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
@@ -6,4 +6,3 @@ bin=`cd "$bin"; pwd`
 source $bin/cloud-install-bash-include.sh
 
 $ACCUMULO_HOME/bin/start-all.sh
-

--- a/dependencies/scripts/start-all.sh
+++ b/dependencies/scripts/start-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`

--- a/dependencies/scripts/start-hadoop.sh
+++ b/dependencies/scripts/start-hadoop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
@@ -11,5 +11,3 @@ $HADOOP_HOME/sbin/start-dfs.sh
 sleep 10
 
 $HADOOP_HOME/bin-mapreduce1/start-mapred.sh
-
-

--- a/dependencies/scripts/start-zookeeper.sh
+++ b/dependencies/scripts/start-zookeeper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`

--- a/dependencies/scripts/stop-accumulo.sh
+++ b/dependencies/scripts/stop-accumulo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
@@ -6,4 +6,3 @@ bin=`cd "$bin"; pwd`
 source $bin/cloud-install-bash-include.sh
 
 $ACCUMULO_HOME/bin/stop-all.sh
-

--- a/dependencies/scripts/stop-all.sh
+++ b/dependencies/scripts/stop-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
@@ -17,5 +17,3 @@ $bin/stop-hadoop.sh
 #stop zookeeper
 
 $bin/stop-zookeeper.sh
-
-

--- a/dependencies/scripts/stop-hadoop.sh
+++ b/dependencies/scripts/stop-hadoop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`
@@ -10,5 +10,3 @@ $HADOOP_HOME/sbin/stop-dfs.sh
 sleep 10
 
 $HADOOP_HOME/bin-mapreduce1/stop-mapred.sh
-
-

--- a/dependencies/scripts/stop-zookeeper.sh
+++ b/dependencies/scripts/stop-zookeeper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 bin=`dirname "${BASH_SOURCE-$0}"`
 bin=`cd "$bin"; pwd`

--- a/dependencies/scripts/zookeeper-init.sh
+++ b/dependencies/scripts/zookeeper-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 export ZOOKEEPER_HOME=/path/to/zookeeper
 export ZOOKEEPER_CONF=$ZOOKEEPER_HOME/conf

--- a/dependencies/scripts/zookeeper-server.sh
+++ b/dependencies/scripts/zookeeper-server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 export ZOOKEEPER_HOME=/path/to/zookeeper
 export ZOOKEEPER_CONF=$ZOOKEEPER_HOME/conf


### PR DESCRIPTION
Hey so /bin/sh wasn't working for me on debian because the default shell isn't bash, and "source" was not recognized. I believe this is the canonical portable way to do bash scripts - it worked for me at least.
